### PR TITLE
DockerでGoの環境構築

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+# Docker image
+FROM golang:latest
+# Working directory in container
+RUN mkdir /go/src/app
+# Directory when logged into the container
+WORKDIR /go/src/app
+# Migrate host files to container working directory
+ADD . /go/src/app

--- a/app/main.go
+++ b/app/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+  fmt.Println("Hello World!")
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+version: "3"
+services:
+  app: # Service name
+    build: . # Place of Dockerfile for build
+    tty: true # Container Persistence
+    volumes:
+      - ./app:/go/src/app # Mount directory


### PR DESCRIPTION
下記記事を元に、Go の環境構築を Docker で行った。

- [dockerを使ってgoの環境構築](https://zenn.dev/tomi/articles/2020-10-14-go-docker)
- [DockerでGoの開発環境を構築する - Qiita](https://qiita.com/uji_/items/8c9eda89526abe0ba900)